### PR TITLE
JSON serialize must return fields as an array, not keyed by UUID

### DIFF
--- a/src-dev/Tests/Unit/GcBaseTestCase.php
+++ b/src-dev/Tests/Unit/GcBaseTestCase.php
@@ -186,27 +186,27 @@ class GcBaseTestCase extends TestCase
             switch ($elementType) {
                 case 'text':
                     $field = static::getUniqueResponseElementTemplateText();
-                    $group['fields'][$field['uuid']] = $field;
+                    $group['fields'][] = $field;
                     break;
 
                 case 'files':
                     $field = static::getUniqueResponseElementTemplateFiles();
-                    $group['fields'][$field['uuid']] = $field;
+                    $group['fields'][] = $field;
                     break;
 
                 case 'guideline':
                     $field = static::getUniqueResponseElementTemplateGuideline();
-                    $group['fields'][$field['uuid']] = $field;
+                    $group['fields'][] = $field;
                     break;
 
                 case 'choice_radio':
                     $field = static::getUniqueResponseElementTemplateChoiceRadio();
-                    $group['fields'][$field['uuid']] = $field;
+                    $group['fields'][] = $field;
                     break;
 
                 case 'choice_checkbox':
                     $field = static::getUniqueResponseElementTemplateChoiceCheckbox();
-                    $group['fields'][$field['uuid']] = $field;
+                    $group['fields'][] = $field;
                     break;
             }
         }

--- a/src/DataTypes/Group.php
+++ b/src/DataTypes/Group.php
@@ -55,4 +55,15 @@ class Group extends Base
 
         return $this;
     }
+
+  public function jsonSerialize() {
+    $json = parent::jsonSerialize();
+
+    // To send a structure to the API, fields must be an array, not keyed
+    // by the UUID.
+    $json['fields'] = array_values($json['fields']);
+
+    return $json;
+  }
+
 }


### PR DESCRIPTION
This solves an error when trying to create a template from a Drupal node type or other bundle